### PR TITLE
DE478702, deprecated array_key_exists on php 7.4

### DIFF
--- a/src/Mongator/Extension/Core.php
+++ b/src/Mongator/Extension/Core.php
@@ -1148,7 +1148,7 @@ EOF
 
     private function mapArrayKeyWithDefault($array, $key, array $mapCallback, $default)
     {
-        if (array_key_exists($key, $array)) {
+        if (property_exists($array, $key)) {
             return call_user_func($mapCallback, $array[$key]);
         }
 


### PR DESCRIPTION
Update Core.php